### PR TITLE
Add desc_for_llm to Team Member Configuration

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -34,6 +34,10 @@ TEAM_MEMBER_CONFIGRATIONS = {
         "desc": (
             "Responsible for searching and collecting relevant information, understanding user needs and conducting research analysis"
         ),
+        "desc_for_llm": (
+            "Uses search engines and web crawlers to gather information from the internet. "
+            "Outputs a Markdown report summarizing findings. Researcher can not do math or programming."
+        ),
         "is_optional": False,
     },
     "coder": {
@@ -41,11 +45,19 @@ TEAM_MEMBER_CONFIGRATIONS = {
         "desc": (
             "Responsible for code implementation, debugging and optimization, handling technical programming tasks"
         ),
+        "desc_for_llm": (
+            "Executes Python or Bash commands, performs mathematical calculations, and outputs a Markdown report. "
+            "Must be used for all mathematical computations."
+        ),
         "is_optional": True,
     },
     "browser": {
         "name": "browser",
         "desc": "Responsible for web browsing, content extraction and interaction",
+        "desc_for_llm": (
+            "Directly interacts with web pages, performing complex operations and interactions. "
+            "You can also leverage `browser` to perform in-domain search, like Facebook, Instgram, Github, etc."
+        ),
         "is_optional": True,
     },
     "reporter": {
@@ -53,6 +65,7 @@ TEAM_MEMBER_CONFIGRATIONS = {
         "desc": (
             "Responsible for summarizing analysis results, generating reports and presenting final outcomes to users"
         ),
+        "desc_for_llm": "Write a professional report based on the result of each step.",
         "is_optional": False,
     },
 }

--- a/src/prompts/planner.md
+++ b/src/prompts/planner.md
@@ -13,10 +13,7 @@ As a Deep Researcher, you can breakdown the major subject into sub-topics and ex
 ## Agent Capabilities
 
 {% for agent in TEAM_MEMBERS %}
-- **`{{agent}}`**: {% if agent == "researcher" %}Uses search engines and web crawlers to gather information from the internet. Outputs a Markdown report summarizing findings. Researcher can not do math or programming.
-{% elif agent == "coder" %}Executes Python or Bash commands, performs mathematical calculations, and outputs a Markdown report. Must be used for all mathematical computations.
-{% elif agent == "browser" %}Directly interacts with web pages, performing complex operations and interactions. You can also leverage `browser` to perform in-domain search, like Facebook, Instagram, Github, etc.
-{% elif agent == "reporter" %}Write a professional report based on the result of each step.{% endif %}
+- **`{{agent}}`**: {{ TEAM_MEMBER_CONFIGRATIONS[agent]["desc_for_llm"] }}
 {% endfor %}
 
 **Note**: Ensure that each step using `coder` and `browser` completes a full task, as session continuity cannot be preserved.

--- a/src/prompts/supervisor.md
+++ b/src/prompts/supervisor.md
@@ -1,10 +1,11 @@
 ---
-CURRENT_TIME: {{ CURRENT_TIME }}
+CURRENT_TIME: { { CURRENT_TIME } }
 ---
 
 You are a supervisor coordinating a team of specialized workers to complete tasks. Your team consists of: [{{ TEAM_MEMBERS|join(", ") }}].
 
 For each user request, you will:
+
 1. Analyze the request and determine which worker is best suited to handle it next
 2. Respond with ONLY a JSON object in the format: {"next": "worker_name"}
 3. Review their response and either:
@@ -14,9 +15,8 @@ For each user request, you will:
 Always respond with a valid JSON object containing only the 'next' key and a single value: either a worker's name or 'FINISH'.
 
 ## Team Members
+
 {% for agent in TEAM_MEMBERS %}
-- **`{{agent}}`**: {% if agent == "researcher" %}Uses search engines and web crawlers to gather information from the internet. Outputs a Markdown report summarizing findings. Researcher can not do math or programming.
-{% elif agent == "coder" %}Executes Python or Bash commands, performs mathematical calculations, and outputs a Markdown report. Must be used for all mathematical computations.
-{% elif agent == "browser" %}Directly interacts with web pages, performing complex operations and interactions. You can also leverage `browser` to perform in-domain search, like Facebook, Instgram, Github, etc.
-{% elif agent == "reporter" %}Write a professional report based on the result of each step.{% endif %}
-{% endfor %}
+
+- **`{{agent}}`**: {{ TEAM_MEMBER_CONFIGRATIONS[agent]["desc_for_llm"] }}
+  {% endfor %}

--- a/tests/integration/test_team_config.py
+++ b/tests/integration/test_team_config.py
@@ -1,0 +1,85 @@
+import pytest
+from src.config import TEAM_MEMBER_CONFIGRATIONS, TEAM_MEMBERS
+from src.prompts.template import get_prompt_template, apply_prompt_template
+
+
+def test_team_member_config_structure():
+    """Test the structure of team member configurations"""
+    required_keys = {"name", "desc", "desc_for_llm", "is_optional"}
+    
+    for member in TEAM_MEMBERS:
+        config = TEAM_MEMBER_CONFIGRATIONS[member]
+        # 检查所有必需的键是否存在
+        assert all(key in config for key in required_keys)
+        # 检查值的类型
+        assert isinstance(config["name"], str)
+        assert isinstance(config["desc"], str)
+        assert isinstance(config["desc_for_llm"], str)
+        assert isinstance(config["is_optional"], bool)
+
+
+def test_desc_for_llm_content():
+    """Test the content of desc_for_llm for each team member"""
+    # 测试每个成员的 desc_for_llm 是否包含必要的关键信息
+    researcher_desc = TEAM_MEMBER_CONFIGRATIONS["researcher"]["desc_for_llm"]
+    assert "search engines" in researcher_desc.lower()
+    assert "web crawlers" in researcher_desc.lower()
+    
+    coder_desc = TEAM_MEMBER_CONFIGRATIONS["coder"]["desc_for_llm"]
+    assert "python" in coder_desc.lower() or "bash" in coder_desc.lower()
+    assert "mathematical" in coder_desc.lower()
+    
+    browser_desc = TEAM_MEMBER_CONFIGRATIONS["browser"]["desc_for_llm"]
+    assert "web pages" in browser_desc.lower()
+    assert "interactions" in browser_desc.lower()
+    
+    reporter_desc = TEAM_MEMBER_CONFIGRATIONS["reporter"]["desc_for_llm"]
+    assert "report" in reporter_desc.lower()
+
+
+def test_template_desc_for_llm_rendering():
+    """Test the rendering of desc_for_llm in templates"""
+    test_state = {
+        "messages": [{"role": "user", "content": "test message"}],
+        "task": "test task",
+        "workspace_context": "test context",
+    }
+    
+    # 测试 planner 模板
+    planner_messages = apply_prompt_template("planner", test_state)
+    planner_content = planner_messages[0]["content"]
+    
+    # 检查是否所有成员的 desc_for_llm 都被正确渲染到模板中
+    for member in TEAM_MEMBERS:
+        desc = TEAM_MEMBER_CONFIGRATIONS[member]["desc_for_llm"]
+        assert desc in planner_content
+    
+    # 测试 supervisor 模板
+    supervisor_messages = apply_prompt_template("supervisor", test_state)
+    supervisor_content = supervisor_messages[0]["content"]
+    
+    # 检查是否所有成员的 desc_for_llm 都被正确渲染到模板中
+    for member in TEAM_MEMBERS:
+        desc = TEAM_MEMBER_CONFIGRATIONS[member]["desc_for_llm"]
+        assert desc in supervisor_content
+
+
+@pytest.mark.parametrize("template_name", ["planner", "supervisor"])
+def test_template_format_after_desc_for_llm(template_name):
+    """Test the template format remains correct after desc_for_llm integration"""
+    test_state = {
+        "messages": [{"role": "user", "content": "test message"}],
+        "task": "test task",
+        "workspace_context": "test context",
+    }
+    
+    messages = apply_prompt_template(template_name, test_state)
+    content = messages[0]["content"]
+    
+    # 检查基本格式是否保持正确
+    assert "---" in content  # 检查 frontmatter
+    assert "CURRENT_TIME:" in content
+    
+    # 检查团队成员列表格式
+    for member in TEAM_MEMBERS:
+        assert f"**`{member}`**:" in content  # 检查成员标题格式 


### PR DESCRIPTION
# Add desc_for_llm to Team Member Configuration

## Overview
This PR introduces a new `desc_for_llm` field to the team member configuration system and updates the corresponding template rendering logic. This enhancement improves the clarity and maintainability of agent descriptions in LLM prompts.

## Changes
- Added `desc_for_llm` field to all team member configurations in `src/config/__init__.py`
- Updated template rendering in `planner.md` and `supervisor.md` to use the new `desc_for_llm` field
- Added comprehensive integration tests in `test_team_config.py` to ensure proper configuration structure and template rendering

## Details
### Configuration Updates
- Added specific LLM-oriented descriptions for each team member:
  - Researcher: Clear description of search and information gathering capabilities
  - Coder: Explicit mention of programming and mathematical computation abilities
  - Browser: Detailed explanation of web interaction capabilities
  - Reporter: Concise description of report generation role

### Template Improvements
- Simplified template logic by using the new `desc_for_llm` field directly
- Maintained consistent formatting while improving readability
- Ensured backward compatibility with existing template structure

### Testing
Added new integration tests to verify:
- Team member configuration structure
- Content requirements for `desc_for_llm`
- Template rendering with the new field
- Format consistency after integration

## Testing Instructions
Run the new integration tests:
```bash
pytest tests/integration/test_team_config.py
```

## Impact
This change improves the maintainability and clarity of our LLM prompts while ensuring consistent agent descriptions across different prompt templates.