### PR TITLE
Add Environment Variable Support for Backend Endpoint Configuration in Frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,3 @@ TAVILY_API_KEY=tvly-xxx
 
 # turn off for collecting anonymous usage information
 ANONYMIZED_TELEMETRY=false
-
-

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Application Settings
 DEBUG=True
 APP_ENV=development
+NEXT_PUBLIC_API_URL="http://localhost:8000/api"
 
 # Add other environment variables as needed
 TAVILY_API_KEY=tvly-xxx
@@ -14,3 +15,5 @@ TAVILY_API_KEY=tvly-xxx
 
 # turn off for collecting anonymous usage information
 ANONYMIZED_TELEMETRY=false
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,12 @@ services:
       context: https://github.com/langmanus/langmanus-web.git#main
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_API_URL=http://localhost:8000/api
+        - NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
     container_name: langmanus-frontend
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:8000/api
+      - NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
     depends_on:
       - backend
     restart: unless-stopped


### PR DESCRIPTION
This PR introduces the ability to configure the backend endpoint URL from the frontend using environment variables. By leveraging environment variables, developers can easily switch between different backend environments (such as development, staging, production) without modifying the codebase. This enhancement improves the flexibility and maintainability of the project and makes it easier to host in various contexts.

Use Case:

I tried to host on my RaspberryPi in VPN then I needed to change NEXT_PUBLIC_API_URL like `http://raspberrypi:8000` in docker-compose.yaml. I thought that such case would happen for some users.

Key changes include:

- Adding a new environment variable `NEXT_PUBLIC_API_URL` to store the backend endpoint URL.
- modify docker-compose.yaml

Please review and let me know if there are any adjustments needed. Thank you!